### PR TITLE
Use TaleWorlds.ObjectSystem namespace in files using MBObjectManager

### DIFF
--- a/CommunityLauncher.SubModule/SubModule.cs
+++ b/CommunityLauncher.SubModule/SubModule.cs
@@ -9,6 +9,7 @@ using CommunityLauncher.Submodule;
 using TaleWorlds.Core;
 using TaleWorlds.Library;
 using TaleWorlds.MountAndBlade;
+using TaleWorlds.ObjectSystem;
 using Module = TaleWorlds.MountAndBlade.Module;
 
 namespace CommunityLauncher.SubModule

--- a/CommunityLauncher.SubModule/XMLSyncMissionNetwork.cs
+++ b/CommunityLauncher.SubModule/XMLSyncMissionNetwork.cs
@@ -1,10 +1,10 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Xml;
-using TaleWorlds.Core;
 using TaleWorlds.Library;
 using TaleWorlds.MountAndBlade;
 using TaleWorlds.MountAndBlade.Network.Messages;
+using TaleWorlds.ObjectSystem;
 
 namespace CommunityLauncher.Submodule
 {


### PR DESCRIPTION
MBObjectManager moved to TaleWorlds.ObjectSystem assembly so the project was not building anymore.